### PR TITLE
update mix file to point to new location of makeup_c

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # MakeupC
-<!-- [![Build Status](https://travis-ci.org/boydm/makeup_c.svg?branch=master)](https://travis-ci.org/boydm/makeup_c)
- -->
 A [Makeup](https://github.com/tmbb/makeup/) lexer for the C language.
 
 ## Installation
@@ -10,7 +8,7 @@ Add `makeup_c` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:makeup_c, "~> 0.1.0"}
+    {:makeup_c, ">= 0.0.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule MakeupC.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
-  @url "https://github.com/boydm/makeup_c"
+  @version "0.1.1"
+  @url "https://github.com/elixir-makeup/makeup_c"
 
   def project do
     [
       app: :makeup_c,
-      version: "0.1.0",
+      version: @version,
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Minor update

:makeup_c is now part of the elixir-makeup org.

Update the github link in the mix file to point to the new location
Clean up the readme a little